### PR TITLE
Rename UpdateState instruction to UpdateOutcome

### DIFF
--- a/programs/hh-escrow/src/instructions/mod.rs
+++ b/programs/hh-escrow/src/instructions/mod.rs
@@ -5,7 +5,7 @@ pub mod initialize_market;
 pub mod initialize_user_position;
 pub mod resolver_acknowledge;
 pub mod set_global_state;
-pub mod update_state;
+pub mod update_outcome;
 pub mod withdraw;
 
 pub use self::claim::*;
@@ -15,5 +15,5 @@ pub use self::initialize_market::*;
 pub use self::initialize_user_position::*;
 pub use self::resolver_acknowledge::*;
 pub use self::set_global_state::*;
-pub use self::update_state::*;
+pub use self::update_outcome::*;
 pub use self::withdraw::*;

--- a/programs/hh-escrow/src/instructions/update_outcome.rs
+++ b/programs/hh-escrow/src/instructions/update_outcome.rs
@@ -6,14 +6,14 @@ use crate::error::ErrorCode;
 use crate::state::{Market, Outcome};
 
 #[derive(Clone, AnchorDeserialize, AnchorSerialize)]
-pub struct UpdateStateParams {
+pub struct UpdateOutcomeParams {
     /// The outcome.
     pub outcome: Outcome,
 }
 
 #[derive(Accounts)]
-#[instruction(params: UpdateStateParams)]
-pub struct UpdateState<'info> {
+#[instruction(params: UpdateOutcomeParams)]
+pub struct UpdateOutcome<'info> {
     /// The market to update.
     #[account(mut)]
     pub market: Account<'info, Market>,
@@ -21,7 +21,7 @@ pub struct UpdateState<'info> {
     pub resolver: Signer<'info>,
 }
 
-impl UpdateState<'_> {
+impl UpdateOutcome<'_> {
     /// Verify that the signing resolver is the market resolver.
     fn verify_resolver(&self) -> Result<()> {
         if *self.resolver.key_ref() != self.market.resolver {
@@ -58,8 +58,8 @@ impl UpdateState<'_> {
     }
 }
 
-pub fn handler(ctx: Context<UpdateState>, params: UpdateStateParams) -> Result<()> {
-    let UpdateStateParams { outcome } = params;
+pub fn handler(ctx: Context<UpdateOutcome>, params: UpdateOutcomeParams) -> Result<()> {
+    let UpdateOutcomeParams { outcome } = params;
 
     let (is_finalized, now) = ctx.accounts.market.is_finalized_and_ts()?;
 

--- a/programs/hh-escrow/src/lib.rs
+++ b/programs/hh-escrow/src/lib.rs
@@ -34,8 +34,8 @@ pub mod hh_escrow {
         instructions::deposit::handler(ctx, params)
     }
 
-    pub fn update_state(ctx: Context<UpdateState>, params: UpdateStateParams) -> Result<()> {
-        instructions::update_state::handler(ctx, params)
+    pub fn update_outcome(ctx: Context<UpdateOutcome>, params: UpdateOutcomeParams) -> Result<()> {
+        instructions::update_outcome::handler(ctx, params)
     }
 
     pub fn withdraw(ctx: Context<Withdraw>) -> Result<()> {

--- a/tests/hh-escrow/claimFlaky.spec.ts
+++ b/tests/hh-escrow/claimFlaky.spec.ts
@@ -322,8 +322,8 @@ describeFlaky("claim (clock-dependent)", () => {
 
     await sleepUntil(expiryTs, 5_000);
 
-    const updateStateIx = await program.methods
-      .updateState({ outcome: { No: {} } })
+    const updateOutcomeIx = await program.methods
+      .updateOutcome({ outcome: { No: {} } })
       .accounts({
         market: market.publicKey,
         resolver: resolver.publicKey,
@@ -331,7 +331,7 @@ describeFlaky("claim (clock-dependent)", () => {
       .instruction();
 
     await claim()
-      .preInstructions([updateStateIx])
+      .preInstructions([updateOutcomeIx])
       .signers([user, resolver])
       .rpc();
 

--- a/tests/hh-escrow/updateOutcome.spec.ts
+++ b/tests/hh-escrow/updateOutcome.spec.ts
@@ -213,7 +213,7 @@ describeFlaky("update state (clock-dependent)", () => {
 
       await expect(
         program.methods
-          .updateState({ outcome })
+          .updateOutcome({ outcome })
           .accounts({
             market: market.publicKey,
             resolver: resolver.publicKey,
@@ -240,7 +240,7 @@ describeFlaky("update state (clock-dependent)", () => {
 
     await expect(
       program.methods
-        .updateState({ outcome: { Invalid: {} } })
+        .updateOutcome({ outcome: { Invalid: {} } })
         .accounts({
           market: market.publicKey,
           resolver: wrongResolver.publicKey,
@@ -261,7 +261,7 @@ describeFlaky("update state (clock-dependent)", () => {
     ];
 
     await program.methods
-      .updateState({ outcome: { Invalid: {} } })
+      .updateOutcome({ outcome: { Invalid: {} } })
       .accounts({
         market: market.publicKey,
         resolver: resolver.publicKey,
@@ -284,7 +284,7 @@ describeFlaky("update state (clock-dependent)", () => {
     const preIxs = [
       await initMarket({ closeTs: intoU64BN(time + 3600) }).instruction(),
       await program.methods
-        .updateState({ outcome: { Invalid: {} } })
+        .updateOutcome({ outcome: { Invalid: {} } })
         .accounts({
           market: market.publicKey,
           resolver: resolver.publicKey,
@@ -293,7 +293,7 @@ describeFlaky("update state (clock-dependent)", () => {
     ];
 
     await program.methods
-      .updateState({ outcome: { Open: {} } })
+      .updateOutcome({ outcome: { Open: {} } })
       .accounts({
         market: market.publicKey,
         resolver: resolver.publicKey,
@@ -324,7 +324,7 @@ describeFlaky("update state (clock-dependent)", () => {
     ];
 
     await program.methods
-      .updateState({ outcome: { Invalid: {} } })
+      .updateOutcome({ outcome: { Invalid: {} } })
       .accounts({
         market: market.publicKey,
         resolver: resolver.publicKey,
@@ -337,7 +337,7 @@ describeFlaky("update state (clock-dependent)", () => {
 
     await expect(
       program.methods
-        .updateState({ outcome: { Open: {} } })
+        .updateOutcome({ outcome: { Open: {} } })
         .accounts({
           market: market.publicKey,
           resolver: resolver.publicKey,
@@ -374,7 +374,7 @@ describeFlaky("update state (clock-dependent)", () => {
       await sleepUntil(expiryTs, 5_000);
 
       await program.methods
-        .updateState({ outcome })
+        .updateOutcome({ outcome })
         .accounts({
           market: market.publicKey,
           resolver: resolver.publicKey,
@@ -410,7 +410,7 @@ describeFlaky("update state (clock-dependent)", () => {
     await sleepUntil(expiryTs, 5_000);
 
     await program.methods
-      .updateState({ outcome: { Open: {} } })
+      .updateOutcome({ outcome: { Open: {} } })
       .accounts({
         market: market.publicKey,
         resolver: program.provider.wallet.publicKey,

--- a/tests/hh-escrow/utils.ts
+++ b/tests/hh-escrow/utils.ts
@@ -22,7 +22,7 @@ type EscrowTypes = IdlTypes<HhEscrow>;
 export type InitializeMarketParams = EscrowTypes["InitializeMarketParams"];
 export type UriResource = EscrowTypes["UriResource"];
 export type DepositParams = EscrowTypes["DepositParams"];
-export type UpdateStateParams = EscrowTypes["UpdateStateParams"];
+export type UpdateOutcomeParams = EscrowTypes["UpdateOutcomeParams"];
 export type Outcome = EscrowTypes["Outcome"];
 
 export const program = new Program(ESCROW_PROGRAM_IDL, ESCROW_PROGRAM_ID);

--- a/tests/hh-escrow/withdraw.spec.ts
+++ b/tests/hh-escrow/withdraw.spec.ts
@@ -329,7 +329,7 @@ describe("withdraw", () => {
     expect(noPosition).toEqualBN(noDeposit);
 
     await program.methods
-      .updateState({ outcome: { Invalid: {} } })
+      .updateOutcome({ outcome: { Invalid: {} } })
       .accounts({
         market: market.publicKey,
         resolver: resolver.publicKey,

--- a/tests/hh-escrow/withdrawFlaky.spec.ts
+++ b/tests/hh-escrow/withdrawFlaky.spec.ts
@@ -228,7 +228,7 @@ describeFlaky("withdraw (clock-dependent)", () => {
 
     const preIxs = [
       await program.methods
-        .updateState({ outcome: { Yes: {} } })
+        .updateOutcome({ outcome: { Yes: {} } })
         .accounts({ market: market.publicKey, resolver: resolver.publicKey })
         .instruction(),
     ];


### PR DESCRIPTION
`UpdateOutcome` is a more descriptive name for the instruction than `UpdateState` (which could be conflated with `SetGlobalState`).